### PR TITLE
updated node version in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ npm run gulp
   - Quickly deploy `public` folder to gh-pages (`gulp deploy` task)
 
 # Basic Usage
-Make sure Node 12.x is installed. I recommend using [NVM](https://github.com/creationix/nvm) to manage versions.
+Make sure Node 0.12.x is installed. I recommend using [NVM](https://github.com/creationix/nvm) to manage versions.
 
 #### Install Dependencies
 ```


### PR DESCRIPTION
while checking out gulp-starter once again I spotted this little typo. By the way I was wondering how the 4.2.x support might be?