### PR TITLE
Added resolve-root jsSrc

### DIFF
--- a/gulpfile.js/lib/webpack-multi-config.js
+++ b/gulpfile.js/lib/webpack-multi-config.js
@@ -18,6 +18,7 @@ module.exports = function(env) {
     context: jsSrc,
     plugins: [],
     resolve: {
+      root: jsSrc,
       extensions: [''].concat(extensions)
     },
     module: {


### PR DESCRIPTION
Taking advantage of the configuration property resolve-root. http://webpack.github.io/docs/configuration.html#resolve-root
This makes file importing inside subfolders a little easier. See example:

Now use:
import Something from 'mydir/myfile';
Old way:
import Something from '../../mydir/myfile';