### PR TITLE
[update] paths in html rev task

### DIFF
--- a/gulpfile.js/tasks/rev/update-html.js
+++ b/gulpfile.js/tasks/rev/update-html.js
@@ -6,7 +6,7 @@ var path       = require('path')
 // 5) Update asset references in HTML
 gulp.task('update-html', function(){
   var manifest = gulp.src(path.join(config.root.dest, "/rev-manifest.json"))
-  return gulp.src(path.join(config.root.dest, '/**/*.html'))
+  return gulp.src(path.join(config.root.dest, config.tasks.html.dest, '/**/*.html'))
     .pipe(revReplace({manifest: manifest}))
-    .pipe(gulp.dest(config.root.dest))
+    .pipe(gulp.dest(path.join(config.root.dest, config.tasks.html.dest)))
 })


### PR DESCRIPTION
@mzlock ran into a path issue on a craft project where she'd changed the html directory paths. This corrects where the html task rev looks for files.