### PR TITLE
Strip all comments. UglifyJS plugin

### DIFF
--- a/gulpfile.js/lib/webpack-multi-config.js
+++ b/gulpfile.js/lib/webpack-multi-config.js
@@ -67,7 +67,11 @@ module.exports = function(env) {
         }
       }),
       new webpack.optimize.DedupePlugin(),
-      new webpack.optimize.UglifyJsPlugin(),
+      new webpack.optimize.UglifyJsPlugin({
+        output: {
+          comments: false
+        }
+      }),
       new webpack.NoErrorsPlugin()
     )
   }


### PR DESCRIPTION
There is an issue with the UglifyJS plugin. You need to set comments:false or you could still get some comments in the code like /*! ... */
See issue here: https://github.com/webpack/webpack/issues/1205