### PR TITLE
gulp-minify-css (deprecated) replaced with gulp-cssnano

### DIFF
--- a/gulpfile.js/tasks/rev/rev-css.js
+++ b/gulpfile.js/tasks/rev/rev-css.js
@@ -1,6 +1,6 @@
 var config = require('../../config')
 var gulp   = require('gulp')
-var minify = require('gulp-minify-css')
+var cssnano = require('gulp-cssnano')
 var path   = require('path')
 var rev    = require('gulp-rev')
 var revNapkin = require('gulp-rev-napkin');
@@ -11,7 +11,7 @@ var uglify = require('gulp-uglify')
 gulp.task('rev-css', function(){
   return gulp.src(path.join(config.root.dest,'/**/*.css'))
     .pipe(rev())
-    .pipe(minify())
+    .pipe(cssnano())
     .pipe(gulp.dest(config.root.dest))
     .pipe(revNapkin({verbose: false}))
     .pipe(rev.manifest(path.join(config.root.dest, 'rev-manifest.json'), {merge: true}))

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "gulp-iconfont": "^4.0.2",
     "gulp-if": "~1.2.5",
     "gulp-imagemin": "^2.3.0",
-    "gulp-minify-css": "^1.2.0",
+    "gulp-cssnano": "^2.1.0",
     "gulp-notify": "^2.2.0",
     "gulp-nunjucks-render": "^0.2.1",
     "gulp-rename": "^1.2.2",


### PR DESCRIPTION
The [gulp-minify-css package has been deprecated](https://www.npmjs.com/package/gulp-minify-css) in favor of gulp-cssnano, which should offer more advanced optimizations. 
This will remove the warning when installing. 