### PR TITLE
Add option to disable rev in config.json

### DIFF
--- a/gulpfile.js/config.json
+++ b/gulpfile.js/config.json
@@ -73,6 +73,10 @@
       "src": "sprites",
       "dest": "images",
       "extensions": ["svg"]
+    },
+
+    "ref" : {
+      "enable": true
     }
   }
 }

--- a/gulpfile.js/lib/webpack-multi-config.js
+++ b/gulpfile.js/lib/webpack-multi-config.js
@@ -9,10 +9,14 @@ module.exports = function(env) {
   var jsSrc = path.resolve(config.root.src, config.tasks.js.src)
   var jsDest = path.resolve(config.root.dest, config.tasks.js.dest)
   var publicPath = path.join(config.tasks.js.dest, '/')
-  var filenamePattern = env === 'production' ? '[name]-[hash].js' : '[name].js'
+  var filenamePattern = '[name].js'
   var extensions = config.tasks.js.extensions.map(function(extension) {
     return '.' + extension
   })
+
+  if(config.tasks.ref.enable === true && env === 'production') {
+    var filenamePattern = '[name]-[hash].js'
+  }
 
   var webpackConfig = {
     context: jsSrc,
@@ -59,8 +63,10 @@ module.exports = function(env) {
   }
 
   if(env === 'production') {
+    if(config.tasks.ref.enable === true) {
+      webpackConfig.plugins.push(new webpackManifest(publicPath, config.root.dest))
+    }
     webpackConfig.plugins.push(
-      new webpackManifest(publicPath, config.root.dest),
       new webpack.DefinePlugin({
         'process.env': {
           'NODE_ENV': JSON.stringify('production')

--- a/gulpfile.js/tasks/rev/index.js
+++ b/gulpfile.js/tasks/rev/index.js
@@ -1,20 +1,26 @@
+var config       = require('../../config')
 var gulp         = require('gulp')
 var gulpSequence = require('gulp-sequence')
 
 // If you are familiar with Rails, this task the equivalent of `rake assets:precompile`
 var revTask = function(cb) {
-  gulpSequence(
-    // 1) Add md5 hashes to assets referenced by CSS and JS files
-    'rev-assets',
-    // 2) Update asset references (images, fonts, etc) with reved filenames in compiled css + js
-    'rev-update-references',
-    // 3) Rev and compress CSS and JS files (this is done after assets, so that if a referenced asset hash changes, the parent hash will change as well
-    'rev-css',
-    // 4) Update asset references in HTML
-    'update-html',
-    // 5) Report filesizes
-    'size-report',
-  cb)
+  if (config.tasks.ref.enable === true) {
+    gulpSequence(
+      // 1) Add md5 hashes to assets referenced by CSS and JS files
+      'rev-assets',
+      // 2) Update asset references (images, fonts, etc) with reved filenames in compiled css + js
+      'rev-update-references',
+      // 3) Rev and compress CSS and JS files (this is done after assets, so that if a referenced asset hash changes, the parent hash will change as well
+      'rev-css',
+      // 4) Update asset references in HTML
+      'update-html',
+      // 5) Report filesizes
+      'size-report',
+    cb)
+  } else {
+    console.log('Skipped rev since it is disabled, enable it in config.json')
+    cb()
+  }
 }
 
 gulp.task('rev', revTask)


### PR DESCRIPTION
I have to switch from revisioned to non revisioned versions according to the project. Some are used in bigger projects which have a revision system themself, others are simply static sites. I found it useful to add a config setting to enable / disable revisioning in the config for that.
Another option I considered was using a different production task for it, but that would need a different name for multiple tasks which seems a not so clean solution.