### PR TITLE
Fix autoprefixer running twice

### DIFF
--- a/gulpfile.js/tasks/rev/rev-css.js
+++ b/gulpfile.js/tasks/rev/rev-css.js
@@ -11,7 +11,7 @@ var uglify = require('gulp-uglify')
 gulp.task('rev-css', function(){
   return gulp.src(path.join(config.root.dest,'/**/*.css'))
     .pipe(rev())
-    .pipe(cssnano())
+    .pipe(cssnano({autoprefixer: false}))
     .pipe(gulp.dest(config.root.dest))
     .pipe(revNapkin({verbose: false}))
     .pipe(rev.manifest(path.join(config.root.dest, 'rev-manifest.json'), {merge: true}))


### PR DESCRIPTION
cssnano runs autoprefixer by default. This overwrites our first run with correct settings.