### PR TITLE
Updates gulp-nunjucks-render to 2.0.0, fixes issue #254

### DIFF
--- a/gulpfile.js/tasks/html.js
+++ b/gulpfile.js/tasks/html.js
@@ -24,16 +24,21 @@ var getData = function(file) {
 }
 
 var htmlTask = function() {
-  render.nunjucks.configure([path.join(config.root.src, config.tasks.html.src)], {watch: false })
 
   return gulp.src(paths.src)
     .pipe(data(getData))
     .on('error', handleErrors)
-    .pipe(render())
+    .pipe(render({
+      path: [path.join(config.root.src, config.tasks.html.src)],
+      envOptions: {
+        watch: false
+      }
+    }))
     .on('error', handleErrors)
     .pipe(gulpif(process.env.NODE_ENV == 'production', htmlmin(config.tasks.html.htmlmin)))
     .pipe(gulp.dest(paths.dest))
     .pipe(browserSync.stream())
+
 }
 
 gulp.task('html', htmlTask)

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "gulp-imagemin": "^2.3.0",
     "gulp-cssnano": "^2.1.0",
     "gulp-notify": "^2.2.0",
-    "gulp-nunjucks-render": "^0.2.1",
+    "gulp-nunjucks-render": "^2.0.0",
     "gulp-rename": "^1.2.2",
     "gulp-rev": "^5.1.0",
     "gulp-rev-napkin": "^0.1.0",


### PR DESCRIPTION
Updates gulp-nunjucks-render dependency to the latest version (2.0.0) and tweaks the `html` task to work with the new API.

In reference to issue #254 this appears to improve error handling (no more Gulp choking on template errors).