### PR TITLE
Enables Webpack dev middleware for BrowserSync proxy configs

### DIFF
--- a/gulpfile.js/tasks/browserSync.js
+++ b/gulpfile.js/tasks/browserSync.js
@@ -10,14 +10,17 @@ var browserSyncTask = function() {
 
   var webpackConfig = webpackMutiConfig('development')
   var compiler = webpack(webpackConfig)
+  var server = config.tasks.browserSync.server || config.tasks.browserSync.proxy || null
 
-  config.tasks.browserSync.server.middleware = [
-    require('webpack-dev-middleware')(compiler, {
-      stats: 'errors-only',
-      publicPath: '/' + webpackConfig.output.publicPath
-    }),
-    require('webpack-hot-middleware')(compiler)
-  ]
+  if (server) {
+    server.middleware = [
+      require('webpack-dev-middleware')(compiler, {
+        stats: 'errors-only',
+        publicPath: '/' + webpackConfig.output.publicPath
+      }),
+      require('webpack-hot-middleware')(compiler)
+    ]
+  }
 
   browserSync.init(config.tasks.browserSync)
 }


### PR DESCRIPTION
Following up on #240: 

Currently, the `browserSync.js` task will throw an error if BrowserSync is set up using a [proxy host](https://www.browsersync.io/docs/options/#option-proxy), due to the `config.tasks.browserSync.server` variable not being set.

This PR fixes this issue and enables dev middleware for proxy configs.