### PR TITLE
Fixes issue with middleware where BrowserSync proxy is a string

### DIFF
--- a/gulpfile.js/tasks/browserSync.js
+++ b/gulpfile.js/tasks/browserSync.js
@@ -10,19 +10,25 @@ var browserSyncTask = function() {
 
   var webpackConfig = webpackMutiConfig('development')
   var compiler = webpack(webpackConfig)
-  var server = config.tasks.browserSync.server || config.tasks.browserSync.proxy || null
 
-  if (server) {
-    server.middleware = [
-      require('webpack-dev-middleware')(compiler, {
-        stats: 'errors-only',
-        publicPath: '/' + webpackConfig.output.publicPath
-      }),
-      require('webpack-hot-middleware')(compiler)
-    ]
+  var proxy = config.tasks.browserSync.proxy || null;
+  if (typeof(proxy) === 'string') {
+    config.tasks.browserSync.proxy = proxy = {
+      target : proxy
+    }
   }
 
+  var server = proxy || config.tasks.browserSync.server;
+  server.middleware = [
+    require('webpack-dev-middleware')(compiler, {
+      stats: 'errors-only',
+      publicPath: '/' + webpackConfig.output.publicPath
+    }),
+    require('webpack-hot-middleware')(compiler)
+  ]
+
   browserSync.init(config.tasks.browserSync)
+  
 }
 
 gulp.task('browserSync', browserSyncTask)


### PR DESCRIPTION
Referencing #263: 

If BrowserSync is configured to use a proxy and the `proxy` config setting is a string (e.g. "http://gulp.dev"), middleware will currently fail silently because BrowserSync requires `proxy` to be an object (where the hostname is the `target` attribute) in order to use middleware.

As BrowserSync permits `proxy` to be a string (where `server` is always an object), I believe Gulp Starter should handle this use case – the end user may not know/care about the middleware option or that it requires the object notation.

This PR revises the browserSync.js task in order to make middleware work for proxy configs, regardless of config format.