### PR TITLE
Minor typo - discrete vs descrete [sic].

### DIFF
--- a/src/javascripts/README.md
+++ b/src/javascripts/README.md
@@ -18,7 +18,7 @@ There are a couple of webpack options exposed in the top-level `gulpfile.js/conf
 Discrete js bundle entry points. A js file will be bundled for each item. Paths are relative to the `javascripts` folder. This maps directly to `webpackConfig.entry`.
 
 ##### `extractSharedJs`
-Creates a `shared.js` file that contains any modules shared by multiple bundles (don't forget to include that on the page!). Useful on large sites with descrete js running on different pages that may share common modules or libraries. For smaller sites, you'll probably want to skip the async stuff, and just compile a single bundle by setting `extractSharedJs` to `false`
+Creates a `shared.js` file that contains any modules shared by multiple bundles (don't forget to include that on the page!). Useful on large sites with discrete js running on different pages that may share common modules or libraries. For smaller sites, you'll probably want to skip the async stuff, and just compile a single bundle by setting `extractSharedJs` to `false`
 
 #### Advanced
 If you want to mess with the specifics of the webpack config, check out `gulpfile.js/lib/webpack-multi-config.js`.


### PR DESCRIPTION

Fix minor typo in the README.md.