### PR TITLE
removed unused var

### DIFF
--- a/gulpfile.js/tasks/clean.js
+++ b/gulpfile.js/tasks/clean.js
@@ -3,7 +3,7 @@ var del    = require('del')
 var config = require('../config')
 
 var cleanTask = function (cb) {
-  del([config.root.dest]).then(function (paths) {
+  del([config.root.dest]).then(function () {
     cb()
   })
 }


### PR DESCRIPTION
When using function (paths), eslint throws an error and the task works fine without the paths variable, as far as I can see..