### PR TITLE
Fix #274: Include subdirectories when processing images

### DIFF
--- a/gulpfile.js/tasks/images.js
+++ b/gulpfile.js/tasks/images.js
@@ -8,7 +8,7 @@ var imagemin    = require('gulp-imagemin')
 var path        = require('path')
 
 var paths = {
-  src: path.join(config.root.src, config.tasks.images.src, '/**.{' + config.tasks.images.extensions + '}'),
+  src: path.join(config.root.src, config.tasks.images.src, '/**/*.{' + config.tasks.images.extensions + '}'),
   dest: path.join(config.root.dest, config.tasks.images.dest)
 }
 


### PR DESCRIPTION
I'm not sure if subfolders were deliberately excluded but here's a PR anyway