### PR TITLE
Fix Gulp Rev with locales

### DIFF
--- a/extras/craft/gulprev/GulpRevPlugin.php
+++ b/extras/craft/gulprev/GulpRevPlugin.php
@@ -10,7 +10,7 @@ class GulpRevPlugin extends BasePlugin
 
     function getVersion()
     {
-        return '1.0';
+        return '1.1';
     }
 
     function getDeveloper()

--- a/extras/craft/gulprev/twigextensions/GulpRevTwigExtension.php
+++ b/extras/craft/gulprev/twigextensions/GulpRevTwigExtension.php
@@ -30,12 +30,20 @@ class GulpRevTwigExtension extends Twig_Extension
 
         // If the file is not defined in the asset manifest
         // just return the original string
-        $path = $file;
+        $path          = $file;
+        $manifest_path = 'rev-manifest.json';
 
-        // looking for rev-manifest file in the public folder
+        // rev-manifest.json should be in the /public folder
+        // just in case locale is on and locale index is in
+        // a subfolder of public, try path one step up
+        if (!file_exists($manifest_path)) {
+            $manifest_path = '../' . $manifest_path;
+        }
+
+        // looking for rev-manifest file
         // and storing the contents of the file
-        if (is_null($manifest) && file_exists('rev-manifest.json')) {
-            $manifest = json_decode(file_get_contents('rev-manifest.json'), true);
+        if (is_null($manifest) && file_exists($manifest_path)) {
+            $manifest = json_decode(file_get_contents($manifest_path), true);
         }
 
         // Find the revved version path of the file in the manifest

--- a/extras/craft/gulprev/twigextensions/GulpRevTwigExtension.php
+++ b/extras/craft/gulprev/twigextensions/GulpRevTwigExtension.php
@@ -31,16 +31,9 @@ class GulpRevTwigExtension extends Twig_Extension
         // If the file is not defined in the asset manifest
         // just return the original string
         $path          = $file;
-        $manifest_path = 'rev-manifest.json';
+        $manifest_path = $_SERVER['DOCUMENT_ROOT'] . '/rev-manifest.json';
 
-        // rev-manifest.json should be in the /public folder
-        // just in case locale is on and locale index is in
-        // a subfolder of public, try path one step up
-        if (!file_exists($manifest_path)) {
-            $manifest_path = '../' . $manifest_path;
-        }
-
-        // looking for rev-manifest file
+        // looking for rev-manifest file in public folder
         // and storing the contents of the file
         if (is_null($manifest) && file_exists($manifest_path)) {
             $manifest = json_decode(file_get_contents($manifest_path), true);


### PR DESCRIPTION
Typically, Craft uses subfolders in `/public` to set up locales.  This throws off asset versioning since the `rev-manifest.json` exists in `/public` and not the locale sub-folder (like `/public/en`).

This just adds a check for the `rev-manifest/json` file one directory up to accomodate this use-case.