### PR TITLE
Fix Browsersync html task reload issue

### DIFF
--- a/gulpfile.js/tasks/html.js
+++ b/gulpfile.js/tasks/html.js
@@ -37,7 +37,7 @@ var htmlTask = function() {
     .on('error', handleErrors)
     .pipe(gulpif(global.production, htmlmin(config.tasks.html.htmlmin)))
     .pipe(gulp.dest(paths.dest))
-    .pipe(browserSync.stream())
+    .on('end', browserSync.reload)
 
 }
 


### PR DESCRIPTION
Fixes #251
Only reload once at the end of the stream to keep browser from reloading too early