### PR TITLE
Fixed the config string for autoprefixer to use "last 3 versions" (plural).

### DIFF
--- a/gulpfile.js/config.json
+++ b/gulpfile.js/config.json
@@ -33,7 +33,7 @@
       "src": "stylesheets",
       "dest": "stylesheets",
       "autoprefixer": {
-        "browsers": ["last 3 version"]
+        "browsers": ["last 3 versions"]
       },
       "sass": {
         "indentedSyntax": true,


### PR DESCRIPTION
The previous string incorrectly used "last 3 version" (singular form).