### PR TITLE
Fix js issues

### DIFF
--- a/gulpfile.js/config.json
+++ b/gulpfile.js/config.json
@@ -24,7 +24,7 @@
       },
       "extensions": ["js", "json"],
       "babel": {
-        "presets": ["es2015", "stage-1"],
+        "presets": ["es2015"],
         "plugins": []
       },
       "extractSharedJs": false

--- a/gulpfile.js/config.json
+++ b/gulpfile.js/config.json
@@ -33,7 +33,7 @@
       "src": "stylesheets",
       "dest": "stylesheets",
       "autoprefixer": {
-        "browsers": ["last 3 version"]
+        "browsers": ["last 3 versions"]
       },
       "sass": {
         "indentedSyntax": true,

--- a/src/javascripts/app.js
+++ b/src/javascripts/app.js
@@ -1,3 +1,3 @@
 import './modules'
 
-console.log(`app.js has loaded!`)
+console.log('app.js has loaded!')


### PR DESCRIPTION
Fixed js string quotes, it was previously using incorrect single-quote chars in app.js.  Removed "stage-1" Babel preset as it is experimental, and currently causing the Gulp build to fail.
