### PR TITLE
Fix #324 update babel-core to 6.10.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:gulp": "mocha ./gulpfile.js/**/*.test.js"
   },
   "devDependencies": {
-    "babel-core": "6.7.2",
+    "babel-core": "^6.10.4",
     "babel-loader": "6.2.4",
     "babel-preset-es2015": "6.6.0",
     "babel-preset-stage-1": "6.5.0",


### PR DESCRIPTION
Resolves issue with Node ^6.5 and the javascript bundle

```
ERROR in ./src/javascripts/app.js
Module build failed: TypeError: Path must be a string. Received undefined
    at assertPath (path.js:7:11)
    at Object.dirname (path.js:1326:5)
    at /Volumes/Data/Users/joemidi/Sites/gulp-starter/node_modules/babel-core/lib/transformation/file/options/option-manager.js:353:36
    at /Volumes/Data/Users/joemidi/Sites/gulp-starter/node_modules/babel-core/lib/transformation/file/options/option-manager.js:375:22
    at Array.map (native)
    at OptionManager.resolvePresets (/Volumes/Data/Users/joemidi/Sites/gulp-starter/node_modules/babel-core/lib/transformation/file/options/option-manager.js:364:20)
    at OptionManager.mergePresets (/Volumes/Data/Users/joemidi/Sites/gulp-starter/node_modules/babel-core/lib/transformation/file/options/option-manager.js:348:10)
    at OptionManager.mergeOptions (/Volumes/Data/Users/joemidi/Sites/gulp-starter/node_modules/babel-core/lib/transformation/file/options/option-manager.js:307:14)
    at /Volumes/Data/Users/joemidi/Sites/gulp-starter/node_modules/babel-core/lib/transformation/file/options/option-manager.js:349:14
    at /Volumes/Data/Users/joemidi/Sites/gulp-starter/node_modules/babel-core/lib/transformation/file/options/option-manager.js:369:24
 @ multi app
```