### PR TITLE
New extra: Docker

### DIFF
--- a/extras/docker/.dockerignore
+++ b/extras/docker/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:4.6.1
+MAINTAINER You <your_email@example.dom>
+
+RUN mkdir /app
+
+WORKDIR /app
+
+COPY package.json ./
+
+RUN ["npm", "install"]
+
+COPY karma.conf.js ./
+COPY gulpfile.js/ ./gulpfile.js
+
+# If you don't plan to deploy this container to production, you can comment this line out, and instead just mount src and public as volumes.
+COPY src/ ./src
+
+CMD ["npm", "run", "gulp", "production"]

--- a/extras/docker/README.md
+++ b/extras/docker/README.md
@@ -1,0 +1,46 @@
+# Gulp Starter on Docker
+
+This extra allows you to run gulp-starter in a Docker container. You can use the included development server, or use Docker to manage assets for another server environment, which may or may not also use Docker. 
+
+## Requirements
+
+Requires [Docker](https://www.docker.com/products/overview), naturally.
+
+## Usage
+
+### In development
+```bash
+git clone https://github.com/vigetlabs/gulp-starter.git MyApp
+cd MyApp
+cp ./extras/docker/Dockerfile .
+cp ./extras/docker/.dockerignore .
+docker build -t myapp .
+docker run -it --rm \
+    -v "$PWD"/src:/app/src \
+    -v "$PWD"/public:/app/public \
+    -p 3000:3000 \
+    myapp \
+    npm start
+```
+Browse to [http://localhost:3000](http://localhost:3000).
+
+### As part of an automated build
+```bash
+docker run --rm myrepo/myimage:mytag npm run gulp production
+```
+
+If you want to use this to process front-end assets for a different server environment, you can do that too. In the BrowserSync section of  [config.json](https://github.com/davidham/gulp-starter/blob/master/gulpfile.js/config.json), set BrowserSync to proxy your app server. Here's an example pointing at a Rails app:
+
+```json
+"browserSync": {
+  "proxy": "http://app:3000",
+  "ghostMode": false,
+  "port": "8080",
+  "ui": {
+    "port": "8081"
+  },
+  "files": "./app/views/**/*"
+}
+```
+
+In this example `app` is the name of the Rails service from a `docker-compose.yml` file (sold separately).

--- a/gulpfile.js/tasks/clean.js
+++ b/gulpfile.js/tasks/clean.js
@@ -3,7 +3,7 @@ var del    = require('del')
 var config = require('../config')
 
 var cleanTask = function (cb) {
-  del([config.root.dest]).then(function (paths) {
+  del([`${config.root.dest}/**`, `!${config.root.dest}` ]).then(function (paths) {
     cb()
   })
 }

--- a/gulpfile.js/tasks/clean.js
+++ b/gulpfile.js/tasks/clean.js
@@ -3,7 +3,7 @@ var del    = require('del')
 var config = require('../config')
 
 var cleanTask = function (cb) {
-  del([`${config.root.dest}/**`, `!${config.root.dest}` ]).then(function (paths) {
+  del([config.root.dest + '/**', '!' + config.root.dest).then(function (paths) {
     cb()
   })
 }


### PR DESCRIPTION
I've been enjoying using gulp-starter with my Rails app. The rest of my project uses Docker, and I wanted to be able to use gulp-starter under docker-compose in development, and to build my assets when I deploy my containers to production.

The only change I had to make to the stock gulp-starter was to update the clean task. I wanted to mount my src and public folders as volumes, but when you do that, the clean task inside the container can't rm the public folder. I modified the task to delete the contents of public but not the folder itself.

Thanks again for gulp-starter, it has been invaluable for me. Hope you find this useful!