### PR TITLE
rm gulp-watch in favor of gulp.watch

### DIFF
--- a/gulpfile.js/tasks/watch.js
+++ b/gulpfile.js/tasks/watch.js
@@ -1,6 +1,5 @@
 var gulp   = require('gulp')
 var path   = require('path')
-var watch  = require('gulp-watch')
 
 var watchTask = function() {
   var watchableTasks = ['fonts', 'iconFont', 'images', 'svgSprite', 'html', 'stylesheets', 'static']
@@ -26,9 +25,8 @@ var watchTask = function() {
 
     if(taskConfig) {
       var glob = path.resolve(process.env.PWD, PATH_CONFIG.src, taskPath.src, '**/*.{' + taskConfig.extensions.join(',') + '}')
-      watch(glob, function() {
-       require('./' + taskName)()
-      })
+      require('./' + taskName)
+      gulp.watch(glob, [taskName])
     }
   })
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "gulp-sourcemaps": "1.9.1",
     "gulp-svgstore": "6.1.0",
     "gulp-util": "3.0.7",
-    "gulp-watch": "4.3.11",
     "karma": "1.3.0",
     "karma-chrome-launcher": "2.0.0",
     "karma-firefox-launcher": "1.0.0",


### PR DESCRIPTION
Hi.

In its current state, this watch task does not work on NFS volume mounts. This PR utilizes `gulp.watch` instead of `gulp-watch` to watch directorys and runs the tasks in response.

I realize this could be a breaking change in some edge cases, but I assumed my scenario was an edge case and it was indeed broken, so perhaps this PR will allow more people to use this.

AFAIK, `gulp-watch` [does not work across NFS mounted volumes](https://github.com/floatdrop/gulp-watch/issues/213) (Vagrant VM developer environments, Docker development environments) unless you explicitly use polling (noooooo). I wouldn't want to force any environments to use polling that didn't have to, and I'd also like to not pollute the task-config with more options / defaults. So I inspected the watch task and noticed that it doesn't really leverage `gulp-watch` very much—it only watches files and runs a task when those files change. It doesn't seem to act on **only** the changed file in any context. So created this PR to remove that dependency and use `gulp.watch` instead. `gulp.watch`, in combination with [activemo=2 option for the NFS mount](https://github.com/gulpjs/gulp/issues/448#issuecomment-43750833). 

Other considerations:
- gulp@4 will utilize chokidar so maybe this will need to be revisited unless it gracefully falls back to polling