### PR TITLE
don't fail silently when task-config has errors

### DIFF
--- a/gulpfile.js/lib/get-task-config.js
+++ b/gulpfile.js/lib/get-task-config.js
@@ -1,8 +1,10 @@
 var path = require('path')
 
 function getTaskConfig() {
+  var config
+
   // Use if already defined
-  if(global.TASK_CONFIG) {
+  if (global.TASK_CONFIG) {
     return global.TASK_CONFIG
   }
 
@@ -18,12 +20,18 @@ function getTaskConfig() {
 
   try {
     // Default Path
-    return require(path.resolve(process.env.PWD, 'config/task-config'))
+    config = require(path.resolve(process.env.PWD, 'config/task-config'))
 
   } catch(e) {
     // Default
-    return require('../task-config')
+    if (/Cannot find module .*\config\/task-config/.test(e.message)) {
+      config = require('../task-config')
+    } else {
+      throw e
+    }
   }
+
+  return config
 }
 
 module.exports = getTaskConfig()


### PR DESCRIPTION
When task-config.json in the project has errors (missing comma, single quotes, etc), the build silently fails and uses the default. This is unexpected and resulted in a bunch of files being written to the wrong (default) directory. The `clean` task and others might be especially harmful. In any event, `get-task-config` can detect a "doesn't exist" error and use the default only in that case. userland errors (in the project's task config) should be exposed by failing nosily.