### PR TITLE
Expose gulp-watch settings

### DIFF
--- a/gulpfile.js/task-config.js
+++ b/gulpfile.js/task-config.js
@@ -49,5 +49,11 @@ module.exports = {
 
   production: {
     rev: true
+  },
+  
+  watch: {
+    gulpWatch: {
+      usePolling: false
+    }
   }
 }

--- a/gulpfile.js/tasks/watch.js
+++ b/gulpfile.js/tasks/watch.js
@@ -23,10 +23,14 @@ var watchTask = function() {
   watchableTasks.forEach(function(taskName) {
     var taskConfig = TASK_CONFIG[taskName]
     var taskPath = getTaskPathFor(taskName)
+    var watchConfig = {}
+    if (TASK_CONFIG.watch !== undefined && TASK_CONFIG.watch.gulpWatch !== undefined) {
+      watchConfig = TASK_CONFIG.watch.gulpWatch
+    }
 
     if(taskConfig) {
       var glob = path.resolve(process.env.PWD, PATH_CONFIG.src, taskPath.src, '**/*.{' + taskConfig.extensions.join(',') + '}')
-      watch(glob, function() {
+      watch(glob, watchConfig, function() {
        require('./' + taskName)()
       })
     }


### PR DESCRIPTION
I need to use `usePolling: true` setting with gulp-watch in order to make it work correctly. It would be useful if this can be enabled in the config file.