### PR TITLE
Fix @font-face loading over webpack

### DIFF
--- a/gulpfile.js/lib/webpack-multi-config.js
+++ b/gulpfile.js/lib/webpack-multi-config.js
@@ -46,6 +46,10 @@ module.exports = function(env) {
           loader: 'babel-loader',
           exclude: /node_modules/,
           query: TASK_CONFIG.javascripts.babel || defaultBabelConfig
+        },
+        {
+          test: /\.(eot|svg|ttf|woff|woff2)$/,
+          loader: 'file-loader',
         }
       ]
     }


### PR DESCRIPTION
Loading local font files via @font-face in CSS failed for me in Chrome with "Failed to decode..." in order to fix this we tell webpack to use the file-loader for font files.