### PR TITLE
Add .editorconfig for uniform code style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
To avoid diefferent code styles we should use .editorconfig file. Maybe there are a bit more options to define. Please extend the configuration by your favor.