### PR TITLE
Change way of invocation from ancestor package (.sh -> .js)

### DIFF
--- a/bin/blendid-karma.js
+++ b/bin/blendid-karma.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+var arguments = require('minimist')(process.argv.slice(2));
+require('child_process').fork(
+  'node_modules/karma/bin/karma',
+  ['start', __dirname+'/../karma.conf'].concat(arguments._[0])
+);

--- a/bin/blendid-karma.sh
+++ b/bin/blendid-karma.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-node node_modules/karma/bin/karma start node_modules/blendid/karma.conf $*

--- a/bin/blendid.js
+++ b/bin/blendid.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+var arguments = require('minimist')(process.argv.slice(2));
+require('child_process').fork(
+  'node_modules/gulp/bin/gulp',
+  ['--gulpfile', __dirname+'/../gulpfile.js'].concat(arguments._[0])
+);

--- a/bin/blendid.sh
+++ b/bin/blendid.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-node node_modules/gulp/bin/gulp.js --gulpfile node_modules/blendid/gulpfile.js $*

--- a/package.json
+++ b/package.json
@@ -7,15 +7,15 @@
     "node": ">=6.3.0",
     "npm": ">=3.10.3"
   },
-  "main": "build_tools/gulpfile.js/index.js",
+  "main": "gulpfile.js/index.js",
   "homepage": "http://code.viget.com/gulp-starter/",
   "repository": {
     "type": "git",
     "url": "git://github.com/vigetlabs/gulp-starter.git"
   },
   "bin": {
-    "blendid": "bin/blendid.sh",
-    "blendid-karma": "bin/blendid-karma.sh"
+    "blendid": "bin/blendid.js",
+    "blendid-karma": "bin/blendid-karma.js"
   },
   "scripts": {
     "start": "gulp",
@@ -64,6 +64,7 @@
     "karma-webpack": "1.8.0",
     "lodash": "4.17.2",
     "merge-stream": "^1.0.1",
+    "minimist": "^1.2.0",
     "mocha": "3.2.0",
     "normalize.css": "5.0.0",
     "object-assign": "4.1.0",


### PR DESCRIPTION
Previously the package was invoked (by "blendid -- build" for instance) via .sh scripts in the /bin/ directory.
Due to missing support in win32 systems for shell scripts this PR solves that by switching from .sh script to .js script that internally spawns a new child process of gulp.