### PR TITLE
Blendid fix cross link

### DIFF
--- a/gulpfile.js/tasks/production.js
+++ b/gulpfile.js/tasks/production.js
@@ -9,7 +9,9 @@ var productionTask = function(cb) {
 
   // Build to a temporary directory, then move compiled files as a last step
   PATH_CONFIG.finalDest = PATH_CONFIG.dest
-  PATH_CONFIG.dest = path.join(os.tmpdir(), 'gulp-starter')
+  PATH_CONFIG.dest = PATH_CONFIG.temp
+    ? path.join(process.env.PWD, PATH_CONFIG.temp)
+    : path.join(os.tmpdir(), 'gulp-starter');
 
   var tasks = getEnabledTasks('production')
   var rev = TASK_CONFIG.production.rev ? 'rev': false

--- a/gulpfile.js/tasks/production.js
+++ b/gulpfile.js/tasks/production.js
@@ -13,7 +13,9 @@ var productionTask = function(cb) {
   PATH_CONFIG.dest = PATH_CONFIG.temp
       ? path.join(process.env.PWD, PATH_CONFIG.temp)
       : path.join(os.tmpdir(), 'gulp-starter');
-  fs.mkdirSync(PATH_CONFIG.dest);
+  if( !fs.existsSync(PATH_CONFIG.dest) ) {
+      fs.mkdirSync(PATH_CONFIG.dest);
+  }
 
   var tasks = getEnabledTasks('production')
   var rev = TASK_CONFIG.production.rev ? 'rev': false

--- a/gulpfile.js/tasks/production.js
+++ b/gulpfile.js/tasks/production.js
@@ -2,6 +2,7 @@ var gulp            = require('gulp')
 var gulpSequence    = require('gulp-sequence')
 var getEnabledTasks = require('../lib/getEnabledTasks')
 var os              = require('os')
+var fs              = require('fs')
 var path            = require('path')
 
 var productionTask = function(cb) {
@@ -10,8 +11,9 @@ var productionTask = function(cb) {
   // Build to a temporary directory, then move compiled files as a last step
   PATH_CONFIG.finalDest = PATH_CONFIG.dest
   PATH_CONFIG.dest = PATH_CONFIG.temp
-    ? path.join(process.env.PWD, PATH_CONFIG.temp)
-    : path.join(os.tmpdir(), 'gulp-starter');
+      ? path.join(process.env.PWD, PATH_CONFIG.temp)
+      : path.join(os.tmpdir(), 'gulp-starter');
+  fs.mkdirSync(PATH_CONFIG.dest);
 
   var tasks = getEnabledTasks('production')
   var rev = TASK_CONFIG.production.rev ? 'rev': false


### PR DESCRIPTION
In some environments the temp directory of the os is not on the same device as the code. In this case you'll get an error like "linking between cross-devices is not permitted" when replaceFiles task is executed.
My solution is to define the temp directory in the path-config file if it's needed and make sure that the directory exists when trying to write to. 