### PR TITLE
Update to latest package of gulp-sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "gulp-sass": "2.3.2",
     "gulp-sequence": "0.4.6",
     "gulp-sizereport": "1.2.0",
-    "gulp-sourcemaps": "1.9.1",
+    "gulp-sourcemaps": "2.2.3",
     "gulp-svgstore": "6.1.0",
     "gulp-util": "3.0.7",
     "gulp-watch": "4.3.11",


### PR DESCRIPTION
due to missing version "1.9.1"

If you want to install the package previously you get an error "Invalid version". Maybe they've unpublished this version. 