### PR TITLE
Generic /node_modules path and support for .njk extension

### DIFF
--- a/gulpfile.js/task-config.js
+++ b/gulpfile.js/task-config.js
@@ -20,7 +20,7 @@ module.exports = {
     sass: {
       indentedSyntax: true,
       includePaths: [
-        "./node_modules/normalize.css"
+        "./node_modules"
       ]
     },
     extensions: ["sass", "scss", "css"]
@@ -31,7 +31,7 @@ module.exports = {
     htmlmin: {
       collapseWhitespace: true
     },
-    extensions: ["html", "json"],
+    extensions: ["html", "njk", "json"],
     excludeFolders: ["layouts", "shared", "macros", "data"]
   },
 
@@ -59,3 +59,4 @@ module.exports = {
     }
   }
 }
+


### PR DESCRIPTION
1. Instead of specific paths for added node_modules, it’s changed to a
generic “/node_modules”. You don’t need to edit this file to add node_modules any more.
2. Added .njk extension to the watch list. Ref.
https://mozilla.github.io/nunjucks/templating.html#file-extensions