### PR TITLE
The babel-preset-react-app plugin needs BABEL_ENV or NODE_ENV

### DIFF
--- a/gulpfile.js/lib/webpack-multi-config.js
+++ b/gulpfile.js/lib/webpack-multi-config.js
@@ -11,6 +11,8 @@ let webpackManifest = require('./webpackManifest')
 let _object = require('lodash/object');
 
 module.exports = function (env) {
+  process.env['BABEL_ENV'] = process.env['BABEL_ENV'] || process.env['NODE_ENV'] || env
+
   let jsSrc = path.resolve(process.env.PWD, PATH_CONFIG.src, PATH_CONFIG.javascripts.src)
   let jsDest = path.resolve(process.env.PWD, PATH_CONFIG.dest, PATH_CONFIG.javascripts.dest)
   let publicPath = pathToUrl(TASK_CONFIG.javascripts.publicPath || PATH_CONFIG.javascripts.dest, '/')


### PR DESCRIPTION
The `babel-preset-react-app` plugin complains when either BABEL_ENV or NODE_ENV is not set to either 'development', 'test' or 'production'. This forces using `BABEL_ENV='development' yarn run blendid` incantation when integrating React.

To fix this, at top of webpack-multi-config, added an enforcement to setup BABEL_ENV to something. It first defaults to itself so that if already set, we do not change anything. Then, default to NODE_ENV if set and finally will be set to webpack env variable if both BABEL_ENV and NODE_ENV are not set.