### PR TITLE
Fixed problems when all asset or code tasks are disabled

### DIFF
--- a/gulpfile.js/lib/__tests__/getEnabledTasks.test.js
+++ b/gulpfile.js/lib/__tests__/getEnabledTasks.test.js
@@ -1,0 +1,145 @@
+var assert = require('chai').assert
+var forEach = require('lodash/forEach')
+var getEnabledTasks = require('../getEnabledTasks')
+var keys = require('lodash/keys')
+
+describe('getEnabledTasks', function() {
+  describe('when env == development', function() {
+    beforeEach(function() {
+      ENV = 'development'
+     });
+
+    describe('#assetTasks', function() {
+      beforeEach(function() {
+        TASK_CONFIG = {
+          fonts: true,
+          iconFont: true,
+          images: true,
+          svgSprite: true
+        }
+       });
+
+      it('returns all tasks when none disabled', function() {
+        var tasks = getEnabledTasks(ENV)
+        assert.deepEqual(tasks.assetTasks, ['fonts', 'iconFont', 'images', 'svgSprite'])
+      })
+
+      it('returns only enabled task when some disabled', function() {
+        TASK_CONFIG['iconFont'] = false
+        TASK_CONFIG['svgSprite'] = false
+
+        var tasks = getEnabledTasks(ENV)
+        assert.deepEqual(tasks.assetTasks, ['fonts', 'images'])
+      })
+
+      it('returns false when all disabled', function() {
+        forEach(keys(TASK_CONFIG), function (key) { TASK_CONFIG[key] = false })
+
+        var tasks = getEnabledTasks(ENV)
+        assert.equal(tasks.assetTasks, false)
+      })
+    })
+
+    describe('#codeTasks', function() {
+      beforeEach(function() {
+        TASK_CONFIG = {
+          html: true,
+          stylesheets: true,
+          javascripts: true
+        }
+       });
+
+      it('returns all except javascripts when none disabled', function() {
+        var tasks = getEnabledTasks(ENV)
+        assert.deepEqual(tasks.codeTasks, ['html', 'stylesheets'])
+      })
+
+      it('returns only enabled except javascripts task when some disabled', function() {
+        TASK_CONFIG['stylesheets'] = false
+
+        var tasks = getEnabledTasks(ENV)
+        assert.deepEqual(tasks.codeTasks, ['html'])
+      })
+
+      it('returns false when all disabled', function() {
+        forEach(keys(TASK_CONFIG), function (key) { TASK_CONFIG[key] = false })
+
+        var tasks = getEnabledTasks(ENV)
+        assert.equal(tasks.codeTasks, false)
+      })
+    })
+  })
+
+  describe('when env == production', function() {
+    beforeEach(function() {
+      ENV = 'production'
+     });
+
+    describe('#assetTasks', function() {
+      beforeEach(function() {
+        TASK_CONFIG = {
+          fonts: true,
+          iconFont: true,
+          images: true,
+          svgSprite: true
+        }
+       });
+
+      it('returns all tasks when none disabled', function() {
+        var tasks = getEnabledTasks(ENV)
+        assert.deepEqual(tasks.assetTasks, ['fonts', 'iconFont', 'images', 'svgSprite'])
+      })
+
+      it('returns only enabled task when some disabled', function() {
+        TASK_CONFIG['iconFont'] = false
+        TASK_CONFIG['svgSprite'] = false
+
+        var tasks = getEnabledTasks(ENV)
+        assert.deepEqual(tasks.assetTasks, ['fonts', 'images'])
+      })
+
+      it('returns false when all disabled', function() {
+        forEach(keys(TASK_CONFIG), function (key) { TASK_CONFIG[key] = false })
+
+        var tasks = getEnabledTasks(ENV)
+        assert.equal(tasks.assetTasks, false)
+      })
+    })
+
+    describe('#codeTasks', function() {
+      beforeEach(function() {
+        TASK_CONFIG = {
+          html: true,
+          stylesheets: true,
+          javascripts: true
+        }
+       });
+
+      it('returns all and convert javascripts task when none disabled', function() {
+        var tasks = getEnabledTasks(ENV)
+        assert.deepEqual(tasks.codeTasks, ['html', 'stylesheets', 'webpack:production'])
+      })
+
+      it('returns only enabled and convert javascripts task when some disabled', function() {
+        TASK_CONFIG['stylesheets'] = false
+
+        var tasks = getEnabledTasks(ENV)
+        assert.deepEqual(tasks.codeTasks, ['html', 'webpack:production'])
+      })
+
+      it('still correctly disable javascripts task when disabled', function() {
+        TASK_CONFIG['javascripts'] = false
+
+        var tasks = getEnabledTasks(ENV)
+        assert.deepEqual(tasks.codeTasks, ['html', 'stylesheets'])
+      })
+
+      it('returns false when all disabled', function() {
+        forEach(keys(TASK_CONFIG), function (key) { TASK_CONFIG[key] = false })
+
+        var tasks = getEnabledTasks(ENV)
+        assert.equal(tasks.codeTasks, false)
+      })
+    })
+  })
+})

--- a/gulpfile.js/lib/getEnabledTasks.js
+++ b/gulpfile.js/lib/getEnabledTasks.js
@@ -1,4 +1,5 @@
 var compact = require('lodash/compact')
+var isEmpty = require('lodash/isEmpty')
 
 // Grouped by what can run in parallel
 var assetTasks = ['fonts', 'iconFont', 'images', 'svgSprite']
@@ -19,8 +20,14 @@ module.exports = function(env) {
     return !!value
   }
 
+  function findExistingTasks(candidates) {
+    var tasks = compact(candidates.map(matchFilter).filter(exists))
+
+    return isEmpty(tasks) ? false : tasks
+  }
+
   return {
-    assetTasks: compact(assetTasks.map(matchFilter).filter(exists)),
-    codeTasks: compact(codeTasks.map(matchFilter).filter(exists))
+    assetTasks: findExistingTasks(assetTasks),
+    codeTasks: findExistingTasks(codeTasks)
   }
 }


### PR DESCRIPTION
When gulp-sequence is faced with an empty array, it seems that it will skip all following tasks in the sequence. For example, facing a call like this: `gulp.sequence('clean', [], ['build', 'assets'], 'watch')`, it will only execute 'clean'. This is caused by the array being empty.

The problem is that if all assets tasks are disabled, it shortcuts the overall sequence which prevents code tasks to be executed for example.

To overcome this, when building `assetTasks` and `codeTasks` objects, we now set them to false if there is no tasks enabled.