### PR TITLE
Expose gh-pages options in config

### DIFF
--- a/gulpfile.js/task-config.js
+++ b/gulpfile.js/task-config.js
@@ -54,6 +54,12 @@ module.exports = {
     gulpWatch: {
       usePolling: false
     }
+  },
+
+  deploy: {
+    ghPages: {
+      branch: "gh-pages"
+    }
   }
 }
 

--- a/gulpfile.js/tasks/deploy.js
+++ b/gulpfile.js/tasks/deploy.js
@@ -6,12 +6,13 @@ var path    = require('path')
 var deployTask = function() {
   var pkg = require(path.resolve(process.env.PWD, 'package.json'))
 
+  var ghPagesSettings = TASK_CONFIG.deploy && TASK_CONFIG.deploy.ghPages || {}
+  ghPagesSettings.cacheDir = ghPagesSettings.cacheDir || path.join(os.tmpdir(), pkg.name)
+
   var settings = {
     url: pkg.homepage,
     src: path.resolve(process.env.PWD, PATH_CONFIG.finalDest, '**/*'),
-    ghPages: {
-      cacheDir: path.join(os.tmpdir(), pkg.name)
-    }
+    ghPages: ghPagesSettings
   }
 
   return gulp.src(settings.src)


### PR DESCRIPTION
Exposes all options from gh-pages https://github.com/shinnn/gulp-gh-pages#api
uses the object 'deploy.ghPages' defined in task-config.js
if no 'cacheDir' option is defined, the previous defined tmp directory is used
Solves Issue #381 

PS: This is my first pull request to an open source project
