### PR TITLE
Add custom task support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 ## Quick start on a fresh project (empty directory)
 ```bash
+yarn init
 yarn add blendid
 yarn run blendid -- init
 yarn run blendid

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ This file exposes per-task configuration and overrides. At minimum, you just nee
 
 - Any task may be disabled by setting the value to `false`. For example, if your project has its own handling HTML and templating (Rails, Craft, Django, etc), you'll want to set `html` to `false` in your task-config.
 - All asset tasks have an `extensions` option that can be used to overwrite the that are processed and watched.
+- The `html` and `stylesheets` tasks may be replaced via their `alternateTask` options
 
 See [task config defaults](gulpfile.js/lib/task-defaults.js) for a closer look. All configuration objects will be merged with these defaults. Note that `array` options are replaced rather than merged or concatinated.
 
@@ -199,6 +200,25 @@ Options to pass to [node-sass](https://github.com/sass/node-sass#options).
 
 Defaults to `{ includePaths: ["./node_modules"]}` so you can `@import` files installed to `node_modules`.
 
+#### `alternateTask`
+If you're not a Sass fan, or for whatever reason, want to use your own task for compiling your stylesheets, you may use the `alternateTask` option to return an alternate function to run as the `stylesheets` task.
+
+```js
+stylesheets: {
+  alternateTask: function(gulp, PATH_CONFIG, TASK_CONFIG) {
+    // PostCSS task instead of Sass
+    return function() {
+      const plugins = [
+          autoprefixer({browsers: ['last 1 version']}),
+          cssnano()
+      ]
+      return gulp.src('./src/*.css')
+          .pipe(postcss(plugins))
+          .pipe(gulp.dest('./dest'))
+    }
+  }
+}
+```
 
 ### html
 **Note:** If you are on a platform that's already handing compiling html (Wordpress, Craft, Rails, etc.), set `html: false` or delete the configuration object completely from `task-config.js`. If that's the case, don't forget to use the BrowserSync [`files` option](https://browsersync.io/docs/options#option-files) in the `browserSync` config object to start watching your templates folder.
@@ -231,6 +251,22 @@ A path to a JSON file containing data to use in your Nunjucks templates via [`gu
 
 #### `excludeFolders`
 You'll want to exclude some folders from being compiled directly. This defaults to: `["layouts", "shared", "macros", "data"]`
+
+#### `alternateTask`
+If you're not a nunjucks fan, or for whatever reason, want to use your own task for compiling your html, you may use the `alternateTask` option to return an alternate function to run as the `html` task.
+
+```js
+html: {
+  alternateTask: function(gulp, PATH_CONFIG, TASK_CONFIG) {
+    // Jade task instead of Nunjucks
+    return function() {
+      gulp
+        .src('./lib/*.jade')
+        .pipe(jade())
+        .pipe(gulp.dest('./dist/'))    }
+  }
+}
+```
 
 ### static
 There are some files that belong in your root destination directory that you won't want to process or revision in production. Things like [favicons, app icons, etc.](http://realfavicongenerator.net/), should go in `src/static`, and will get copied over to `public` as a last step (after revisioning in production). *Nothing* should ever go directly in `public`, since it gets completely trashed and re-built when running the `default` or `production` tasks.
@@ -308,10 +344,54 @@ production: {
 }
 ```
 
+### additionalTasks
+If you wish to define additional gulp tasks, and have them run at a certain point in the build process, you may use this configuration to do so via the following config object:
+
+```js
+additionalTasks: {
+  initialize(gulp, PATH_CONFIG, TASK_CONFIG) {
+    // Add gulp tasks here
+  },
+  development: {
+    prebuild: [],
+    postbuild: []
+  },
+  production: {
+    prebuild: [],
+    postbuild: []
+  }
+}
+```
+
+Blendid will call `initialize`, passing in `gulp`, along with the path and task configs. Use this method to define or `require` additional gulp tasks. You can specify when and in what order your custom tasks should run in the `production` and `development` `prebuild` and `postbuild` options.
+
+For example, say you had a sprite task you wanted to run before your css compiled, and in production, you wanted to run an image compression task you had after all assets had been compiled. Your configuration might look something like this:
+
+```
+additionalTasks: {
+  initialize(gulp, PATH_CONFIG, TASK_CONFIG) {
+    gulp.task('createPngSprite', function() {
+      // do stuff
+    })
+    gulp.task('compressImages', function() {
+      // compress all the things
+    })
+  },
+  development: {
+    prebuild: ['createPngSprite'],
+    postbuild: []
+  },
+  production: {
+    prebuild: ['createPngSprite'],
+    postbuild: ['compressImages']
+  }
+}
+```
+
 # FAQ
 
 ## Can I customize and add Gulp tasks?
-See #352. In the meantime, you could clone this repo, copy over the gulpfile.js folder and package.json dependencies and run `gulp` instead of installing it as a module directly, or your could fork and maintain your own custom setup.
+Yep! See [additionalTasks](#additionalTasks), as well as the `task` option of  the [`stylesheets`](stylesheets) and [`html`](html) configs.
 
 ## I don't see JS files in my dest directory during development
 JS files are compiled and live-update via BrowserSync + WebpackDevMiddleware + WebpackHotMiddleware. That means, that you won't actually see `.js` files output to your destination directory during development, but they will be available to your browser running on the BrowserSync port.

--- a/gulpfile.js/index.js
+++ b/gulpfile.js/index.js
@@ -1,10 +1,3 @@
-var path = require('path')
-
-// Fallback for windows backs out of node_modules folder to root of project
-process.env.PWD = process.env.PWD || path.resolve(process.cwd(), '../../')
-global.PATH_CONFIG = require('./lib/get-path-config')
-global.TASK_CONFIG = require('./lib/get-task-config')
-
 /*
   gulpfile.js
   ===========
@@ -12,13 +5,21 @@ global.TASK_CONFIG = require('./lib/get-task-config')
   for creating multiple tasks, each task has been broken out into
   its own file in gulpfile.js/tasks. Any files in that directory get
   automatically required below.
-
-  To add a new task, simply add a new task file that directory.
-  gulpfile.js/tasks/default.js specifies the default set of tasks to run
-  when you run `gulp`.
 */
 
-var requireDir = require('require-dir')
+const path = require('path')
+const gulp = require('gulp')
+const requireDir = require('require-dir')
+
+// Fallback for windows backs out of node_modules folder to root of project
+process.env.PWD = process.env.PWD || path.resolve(process.cwd(), '../../')
+
+// Globally expose config objects
+global.PATH_CONFIG = require('./lib/get-path-config')
+global.TASK_CONFIG = require('./lib/get-task-config')
 
 // Require all tasks in gulpfile.js/tasks, including subfolders
 requireDir('./tasks', { recurse: true })
+
+// Initialize any additional user-provided tasks
+TASK_CONFIG.additionalTasks.initialize(gulp, PATH_CONFIG, TASK_CONFIG)

--- a/gulpfile.js/lib/task-defaults.js
+++ b/gulpfile.js/lib/task-defaults.js
@@ -55,7 +55,7 @@ module.exports = {
 
   ghPages: {
     branch: "gh-pages",
-    cacheDir: path.join(os.tmpdir(), pkg.name)
+    cacheDir: path.join(os.tmpdir(), pkg.name || "blendid")
   },
 
   svgSprite: {

--- a/gulpfile.js/lib/task-defaults.js
+++ b/gulpfile.js/lib/task-defaults.js
@@ -64,6 +64,20 @@ module.exports = {
 
   production: {
     rev: true
+  },
+
+  additionalTasks: {
+    initialize(gulp, PATH_CONFIG, TASK_CONFIG) {
+      // gulp.task('myTask', function() { })
+    },
+    development: {
+      prebuild: null,
+      postbuild: null
+    },
+    production: {
+      prebuild: null,
+      postbuild: null
+    }
   }
 }
 

--- a/gulpfile.js/lib/webpack-multi-config.js
+++ b/gulpfile.js/lib/webpack-multi-config.js
@@ -85,7 +85,7 @@ module.exports = function (env) {
         }
       }),
       new webpack.optimize.UglifyJsPlugin(),
-      new webpack.NoErrorsPlugin()
+      new webpack.NoEmitOnErrorsPlugin()
     )
   }
 

--- a/gulpfile.js/tasks/clean.js
+++ b/gulpfile.js/tasks/clean.js
@@ -1,8 +1,8 @@
-var gulp = require('gulp')
-var del  = require('del')
-var path = require('path')
+const gulp = require('gulp')
+const del  = require('del')
+const path = require('path')
 
-var cleanTask = function (cb) {
+const cleanTask = function (cb) {
   return del([path.resolve(process.env.PWD, PATH_CONFIG.dest)], { force: true })
 }
 

--- a/gulpfile.js/tasks/default.js
+++ b/gulpfile.js/tasks/default.js
@@ -5,7 +5,8 @@ var getEnabledTasks = require('../lib/getEnabledTasks')
 var defaultTask = function(cb) {
   var tasks = getEnabledTasks('watch')
   var static = TASK_CONFIG.static ? 'static' : false
-  gulpSequence('clean', tasks.assetTasks, tasks.codeTasks, static, 'watch', cb)
+  const { prebuild, postbuild } = TASK_CONFIG.additionalTasks.development
+  gulpSequence('clean', prebuild, tasks.assetTasks, tasks.codeTasks, static, postbuild, 'watch', cb)
 }
 
 gulp.task('default', defaultTask)

--- a/gulpfile.js/tasks/html.js
+++ b/gulpfile.js/tasks/html.js
@@ -37,5 +37,7 @@ const htmlTask = function() {
     .pipe(browserSync.stream())
 }
 
-gulp.task('html', htmlTask)
-module.exports = htmlTask
+const { alternateTask = () => htmlTask } = TASK_CONFIG.html
+const task = alternateTask(gulp, PATH_CONFIG, TASK_CONFIG)
+gulp.task('html', task)
+module.exports = task

--- a/gulpfile.js/tasks/production.js
+++ b/gulpfile.js/tasks/production.js
@@ -1,11 +1,11 @@
-var gulp            = require('gulp')
-var gulpSequence    = require('gulp-sequence')
-var getEnabledTasks = require('../lib/getEnabledTasks')
-var os              = require('os')
-var fs              = require('fs')
-var path            = require('path')
+const gulp            = require('gulp')
+const gulpSequence    = require('gulp-sequence')
+const getEnabledTasks = require('../lib/getEnabledTasks')
+const os              = require('os')
+const fs              = require('fs')
+const path            = require('path')
 
-var productionTask = function(cb) {
+const productionTask = function(cb) {
   global.production = true
 
   // Build to a temporary directory, then move compiled files as a last step
@@ -17,11 +17,12 @@ var productionTask = function(cb) {
       fs.mkdirSync(PATH_CONFIG.dest);
   }
 
-  var tasks = getEnabledTasks('production')
-  var rev = TASK_CONFIG.production.rev ? 'rev': false
-  var static = TASK_CONFIG.static ? 'static' : false
+  const tasks = getEnabledTasks('production')
+  const rev = TASK_CONFIG.production.rev ? 'rev': false
+  const static = TASK_CONFIG.static ? 'static' : false
+  const { prebuild, postbuild } = TASK_CONFIG.additionalTasks.production
 
-  gulpSequence('clean', tasks.assetTasks, tasks.codeTasks, rev, 'size-report', static, 'replaceFiles', cb)
+  gulpSequence('clean', prebuild, tasks.assetTasks, tasks.codeTasks, rev, 'size-report', static, postbuild, 'replaceFiles', cb)
 }
 
 gulp.task('build', productionTask)

--- a/gulpfile.js/tasks/static.js
+++ b/gulpfile.js/tasks/static.js
@@ -1,16 +1,15 @@
 if(!TASK_CONFIG.static) return
 
-var changed = require('gulp-changed')
-var gulp    = require('gulp')
-var path    = require('path')
+const changed = require('gulp-changed')
+const gulp    = require('gulp')
+const path    = require('path')
 
+const staticTask = function() {
+  const srcPath = path.resolve(process.env.PWD, PATH_CONFIG.src, PATH_CONFIG.static.src)
+  const defaultSrcOptions = { dot: true }
+  const options = Object.assign(defaultSrcOptions, (TASK_CONFIG.static.srcOptions || {}))
 
-var staticTask = function() {
-  var srcPath = path.resolve(process.env.PWD, PATH_CONFIG.src, PATH_CONFIG.static.src)
-  var defaultSrcOptions = { dot: true }
-  var options = Object.assign(defaultSrcOptions, (TASK_CONFIG.static.srcOptions || {}))
-
-  var paths = {
+  const paths = {
     src: [
       path.join(srcPath, '**/*'),
       path.resolve(process.env.PWD, '!' + PATH_CONFIG.src, PATH_CONFIG.static.src, 'README.md')

--- a/gulpfile.js/tasks/stylesheets.js
+++ b/gulpfile.js/tasks/stylesheets.js
@@ -10,7 +10,7 @@ var autoprefixer = require('gulp-autoprefixer')
 var path         = require('path')
 var cssnano      = require('gulp-cssnano')
 
-var stylesheetsTask = function () {
+var sassTask = function () {
 
   var paths = {
     src: path.resolve(process.env.PWD, PATH_CONFIG.src, PATH_CONFIG.stylesheets.src, '**/*.{' + TASK_CONFIG.stylesheets.extensions + '}'),
@@ -36,6 +36,9 @@ var stylesheetsTask = function () {
     .pipe(gulp.dest(paths.dest))
     .pipe(browserSync.stream())
 }
+
+const { alternateTask = () => sassTask } = TASK_CONFIG.stylesheets
+const stylesheetsTask = alternateTask(gulp, PATH_CONFIG, TASK_CONFIG)
 
 gulp.task('stylesheets', stylesheetsTask)
 module.exports = stylesheetsTask

--- a/gulpfile.js/tasks/svgSprite.js
+++ b/gulpfile.js/tasks/svgSprite.js
@@ -18,5 +18,7 @@ const svgSpriteTask = function() {
     .pipe(browserSync.stream())
 }
 
-gulp.task('svgSprite', svgSpriteTask)
-module.exports = svgSpriteTask
+const { alternateTask = () => svgSpriteTask } = TASK_CONFIG.svgSprite
+const task = alternateTask(gulp, PATH_CONFIG, TASK_CONFIG)
+gulp.task('svgSprite', task)
+module.exports = task

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blendid",
-  "version": "4.0.0-rc.11",
+  "version": "4.0.0-rc.12",
   "description": "(formerly gulp-starter) A full featured configurable gulp asset pipeline and static site builder",
   "license": "MIT",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blendid",
-  "version": "4.0.0-rc.12",
+  "version": "4.0.0-rc.13",
   "description": "(formerly gulp-starter) A full featured configurable gulp asset pipeline and static site builder",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
New task-config options to allow custom tasks 🎉 
Resolves #352

If anyone wants to take it for as spin:

```
yarn upgrade blendid@4.0.0-rc.12
````

## additionalTasks
If you wish to define additional gulp tasks, and have them run at a certain point in the build process, you may use this configuration to do so via the following config object:

```js
additionalTasks: {
  initialize(gulp, PATH_CONFIG, TASK_CONFIG) {
    // Add gulp tasks here
  },
  development: {
    prebuild: [],
    postbuild: []
  },
  production: {
    prebuild: [],
    postbuild: []
  }
}
```

Blendid will call `initialize`, passing in `gulp`, along with the path and task configs. Use this method to define or `require` additional gulp tasks. You can specify when and in what order your custom tasks should run in the `production` and `development` `prebuild` and `postbuild` options.

For example, say you had a sprite task you wanted to run before your css compiled, and in production, you wanted to run an image compression task you had after all assets had been compiled. Your configuration might look something like this:

```
additionalTasks: {
  initialize(gulp, PATH_CONFIG, TASK_CONFIG) {
    gulp.task('createPngSprite', function() {
      // do stuff
    })
    gulp.task('compressImages', function() {
      // compress all the things
    })
  },
  development: {
    prebuild: ['createPngSprite'],
    postbuild: []
  },
  production: {
    prebuild: ['createPngSprite'],
    postbuild: ['compressImages']
  }
}
```


## Specify an alternate `html` task
#### `alternateTask`
If you're not a nunjucks fan, or for whatever reason, want to use your own task for compiling your html, you may use the `alternateTask` option to return an alternate function to run as the `html` task.

```js
html: {
  alternateTask: function(gulp, PATH_CONFIG, TASK_CONFIG) {
    // Jade task instead of Nunjucks
    return function() {
      gulp
        .src('./lib/*.jade')
        .pipe(jade())
        .pipe(gulp.dest('./dist/'))    }
  }
}
```

## Specify an alternate `stylesheets` task
#### `alternateTask`
If you're not a Sass fan, or for whatever reason, want to use your own task for compiling your stylesheets, you may use the `alternateTask` option to return an alternate function to run as the `stylesheets` task.

```js
stylesheets: {
  alternateTask: function(gulp, PATH_CONFIG, TASK_CONFIG) {
    // PostCSS task instead of Sass
    return function() {
      const plugins = [
          autoprefixer({browsers: ['last 1 version']}),
          cssnano()
      ]
      return gulp.src('./src/*.css')
          .pipe(postcss(plugins))
          .pipe(gulp.dest('./dest'))
    }
  }
}
```